### PR TITLE
Next release

### DIFF
--- a/src/main/java/com/github/dtreskunov/easyssl/CertificateExpirationWarning.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/CertificateExpirationWarning.java
@@ -1,0 +1,34 @@
+package com.github.dtreskunov.easyssl;
+
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.TemporalAmount;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CertificateExpirationWarning {
+    private static final Logger LOG = LoggerFactory.getLogger(CertificateExpirationWarning.class);
+
+    /**
+     * Logs a warning when any certificate in the chain is close to expiring.
+     * @param chain
+     * @param provenance added to the log message to help disambiguate which certificate is expiring
+     * @param warningThreshold how close to expiring the certificate needs to be before a warning is logged
+     */
+    public static void check(X509Certificate[] chain, String provenance, TemporalAmount warningThreshold) {
+        if (chain == null || chain.length == 0) {
+            return;
+        }
+        Instant warnIfExpiresBefore = Instant.now().plus(warningThreshold);
+
+        for (int i=0; i<chain.length; i++) {
+            X509Certificate cert = chain[i];
+            if (cert.getNotAfter().toInstant().isBefore(warnIfExpiresBefore)) {
+                LOG.warn("{} certificate i={} sub='{}' iss='{}' serial={} expires on {} (less than {} from now)",
+                    provenance, i, cert.getSubjectX500Principal(), cert.getIssuerX500Principal(), cert.getSerialNumber(),
+                    cert.getNotAfter(), warningThreshold);
+            }
+        }
+    }
+}

--- a/src/main/java/com/github/dtreskunov/easyssl/ExpirationWarningTrustManager.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/ExpirationWarningTrustManager.java
@@ -2,22 +2,16 @@ package com.github.dtreskunov.easyssl;
 
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.time.Instant;
 import java.time.temporal.TemporalAmount;
 
 import javax.net.ssl.X509TrustManager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.util.Assert;
 
 /**
- * Logs a warning when any certificatein the chain is close to expiring.
+  * Logs a warning when any certificate in the chain is close to expiring.
  */
 public class ExpirationWarningTrustManager implements X509TrustManager {
-    private static final Logger LOG = LoggerFactory.getLogger(ExpirationWarningTrustManager.class);
-    private static final String CLIENT = "client";
-    private static final String SERVER = "server";
     private TemporalAmount warningThreshold;
 
     public ExpirationWarningTrustManager(TemporalAmount warningThreshold) {
@@ -27,12 +21,12 @@ public class ExpirationWarningTrustManager implements X509TrustManager {
 
     @Override
     public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-        check(chain, CLIENT);
+        CertificateExpirationWarning.check(chain, "remote client", warningThreshold);
     }
 
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-        check(chain, SERVER);
+        CertificateExpirationWarning.check(chain, "remote server", warningThreshold);
     }
 
     @Override
@@ -40,19 +34,4 @@ public class ExpirationWarningTrustManager implements X509TrustManager {
         return null;
     }
 
-    private void check(X509Certificate[] chain, String provenance) {
-        if (chain == null || chain.length == 0) {
-            return;
-        }
-        Instant warnIfExpiresBefore = Instant.now().plus(warningThreshold);
-
-        for (int i=0; i<chain.length; i++) {
-            X509Certificate cert = chain[i];
-            if (cert.getNotAfter().toInstant().isBefore(warnIfExpiresBefore)) {
-                LOG.warn("{} certificate i={} sub='{}' iss='{}' serial={} expires on {} (less than {} from now)",
-                    provenance, i, cert.getSubjectX500Principal(), cert.getIssuerX500Principal(), cert.getSerialNumber(),
-                    cert.getNotAfter(), warningThreshold);
-            }
-        }
-    }
 }

--- a/src/main/java/com/github/dtreskunov/easyssl/ThreadFactoryFactory.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/ThreadFactoryFactory.java
@@ -1,0 +1,18 @@
+package com.github.dtreskunov.easyssl;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+/**
+ * Very enterprise. Much Java.
+ */
+public class ThreadFactoryFactory {
+    public static ThreadFactory createThreadFactory(boolean daemon, String name) {
+        return runnable -> {
+            Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+            thread.setDaemon(daemon);
+            thread.setName(name);
+            return thread;
+        };
+    }
+}

--- a/src/main/java/com/github/dtreskunov/easyssl/TimeoutUtils.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/TimeoutUtils.java
@@ -94,13 +94,8 @@ public class TimeoutUtils {
          * @throws TimeoutException if the wait timed out
          */
         public <T> T call(Callable<T> callable) throws ExecutionException, InterruptedException, TimeoutException {
-            ExecutorService executor = Executors.newSingleThreadExecutor(runnable -> {
-                Thread thread = Executors.defaultThreadFactory().newThread(runnable);
-                String name = m_name + (m_daemon ? " daemon" : " notdaemon");
-                thread.setDaemon(m_daemon);
-                thread.setName(name);
-                return thread;
-            });
+            ExecutorService executor = Executors.newSingleThreadExecutor(
+                ThreadFactoryFactory.createThreadFactory(m_daemon, m_name + (m_daemon ? " daemon" : " notdaemon")));
 
             Future<T> future = executor.submit(callable);
             executor.shutdown();

--- a/src/main/java/com/github/dtreskunov/easyssl/spring/EasySslBeans.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/spring/EasySslBeans.java
@@ -145,6 +145,9 @@ public class EasySslBeans {
         try (PEMParser pemParser = new PEMParser(new InputStreamReader(inputStream, Charset.defaultCharset()))) {
             pemObject = pemParser.readObject();
         }
+        if (pemObject == null) {
+            throw new KeyException("No object was extracted from the input stream by the PEM parser");
+        }
 
         JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
         final PEMKeyPair pemKeyPair;

--- a/src/main/java/com/github/dtreskunov/easyssl/spring/EasySslProperties.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/spring/EasySslProperties.java
@@ -51,6 +51,7 @@ public class EasySslProperties {
     private boolean m_serverCustomizationEnabled = true;
     private ClientAuth m_clientAuth = ClientAuth.NEED;
     private Duration m_certificateExpirationWarningThreshold;
+    private Duration m_certificateExpirationWarningInterval;
 
     /**
      * @return Certificate Authority's (CA) certificate(s), used for validating client and server certificates, and the signature on the CRL.
@@ -129,6 +130,13 @@ public class EasySslProperties {
         return m_certificateExpirationWarningThreshold;
     }
 
+    /**
+     * @return How frequently to check the local certificate for expiration.
+     */
+    public Duration getCertificateExpirationWarningInterval() {
+        return m_certificateExpirationWarningInterval;
+    }
+
     public void setCaCertificate(List<Resource> caCertificate) {
         m_caCertificate = caCertificate;
     }
@@ -161,5 +169,8 @@ public class EasySslProperties {
     }
     public void setCertificateExpirationWarningThreshold(Duration certificateExpirationWarningThreshold) {
         m_certificateExpirationWarningThreshold = certificateExpirationWarningThreshold;
+    }
+    public void setCertificateExpirationWarningInterval(Duration certificateExpirationWarningInterval) {
+        m_certificateExpirationWarningInterval = certificateExpirationWarningInterval;
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -8,6 +8,7 @@ easyssl:
   key: file:src/test/resources/ssl/localhost1/key.pem
   keyPassword: localhost1-password
   certificateExpirationWarningThreshold: 30d
+  certificateExpirationWarningInterval: 1d
   certificateRevocationList: file:src/test/resources/ssl/ca/crl.pem
   certificateRevocationListCheckIntervalSeconds: 2
   certificateRevocationListCheckTimeoutSeconds: 1


### PR DESCRIPTION
1. Fix NPE in EasySslBeans.getPrivateKey
  A `NullPointerException` was getting thrown when `PEMParser` returned null. Per `PERParser.readObject()` docs: "returns the next object in the stream, null if no objects left"

2. Warn if the local certificate will expire soon
  A new app property `easyssl.certificateExpirationWarningInterval` controls how often the local certificate will be checked (if not set, then it will only be checked once on startup).

3. Change the logger that receives certificate expiration messages from `com.github.dtreskunov.easyssl.ExpirationWarningTrustManager` to `com.github.dtreskunov.easyssl.CertificateExpirationWarning`.