### PR TITLE
added ref: resource protocol

### DIFF
--- a/src/main/java/com/github/dtreskunov/easyssl/ext/AbstractNamedResource.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/ext/AbstractNamedResource.java
@@ -1,0 +1,34 @@
+package com.github.dtreskunov.easyssl.ext;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.core.io.AbstractResource;
+import org.springframework.util.Assert;
+
+abstract class AbstractNamedResource extends AbstractResource {
+
+    private final String m_name;
+
+    public AbstractNamedResource(String name) {
+        Assert.notNull(name, "name cannot be null");
+        m_name = name;
+    }
+
+    abstract String getValue(String name);
+
+    @Override
+    public String getDescription() {
+        return "Contents of " + getClass().getSimpleName() + " named " + m_name;
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        String value = getValue(m_name);
+        if (value == null) {
+            throw new IOException(getDescription() + " is null");
+        }
+        return new ByteArrayInputStream(value.getBytes());
+    }
+}

--- a/src/main/java/com/github/dtreskunov/easyssl/ext/EnvProtocolBeans.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/ext/EnvProtocolBeans.java
@@ -1,16 +1,13 @@
 package com.github.dtreskunov.easyssl.ext;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.AbstractResource;
 import org.springframework.core.io.ProtocolResolver;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
-import org.springframework.util.Assert;
 
 /**
  * Allows specifying Spring {@link Resource}s as literals from environment
@@ -40,35 +37,15 @@ public class EnvProtocolBeans {
         }
     }
 
-    public static class EnvironmentVariableNotSetException extends IOException {
-        private static final long serialVersionUID = 1L;
-
-        public EnvironmentVariableNotSetException(String message) {
-            super(message);
-        }
-    }
-
-    static class EnvironmentVariableResource extends AbstractResource {
-
-        private final String m_name;
+    static class EnvironmentVariableResource extends AbstractNamedResource {
 
         public EnvironmentVariableResource(String name) {
-            Assert.notNull(name, "name cannot be null");
-            m_name = name;
+            super(name);
         }
 
         @Override
-        public String getDescription() {
-            return "Contents of environment variable " + m_name;
-        }
-
-        @Override
-        public InputStream getInputStream() throws IOException {
-            String value = System.getenv(m_name);
-            if (value == null) {
-                throw new EnvironmentVariableNotSetException(m_name);
-            }
-            return new ByteArrayInputStream(value.getBytes());
+        String getValue(String name) {
+            return System.getenv(name);
         }
     }
 }

--- a/src/main/java/com/github/dtreskunov/easyssl/ext/RefProtocolBeans.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/ext/RefProtocolBeans.java
@@ -1,0 +1,62 @@
+package com.github.dtreskunov.easyssl.ext;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.ProtocolResolver;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.util.Assert;
+
+/**
+ * Allows specifying Spring {@link Resource}s as literals referencing application
+ * properties. For example, {@code ref:message} will result in a resource
+ * that will read from application property {@code message} when an
+ * {@link InputStream} is requested (if {@code message} is not set, an
+ * {@link IOException} is thrown).
+ */
+@Configuration
+public class RefProtocolBeans {
+
+    @Bean
+    ProtocolResolverRegistrar refProtocolResolverRegistrar(Environment environment) {
+        return new ProtocolResolverRegistrar(new RefProtocolResolver(environment));
+    }
+
+    static class RefProtocolResolver implements ProtocolResolver {
+        public static final String PROTOCOL_PREFIX = "ref:";
+        private final Environment environment;
+
+        public RefProtocolResolver(Environment environment) {
+            Assert.notNull(environment, "environment cannot be null");
+            this.environment = environment;
+        }
+
+        @Override
+        public Resource resolve(String location, ResourceLoader resourceLoader) {
+            if (!location.startsWith(PROTOCOL_PREFIX)) {
+                return null;
+            }
+            String name = location.substring(PROTOCOL_PREFIX.length());
+            return new ApplicationPropertyResource(name, environment);
+        }
+    }
+
+    static class ApplicationPropertyResource extends AbstractNamedResource {
+        private final Environment environment;
+
+        public ApplicationPropertyResource(String name, Environment environment) {
+            super(name);
+            Assert.notNull(environment, "environment cannot be null");
+            this.environment = environment;
+        }
+
+        @Override
+        String getValue(String name) {
+            return environment.getProperty(name);
+        }
+    }
+}

--- a/src/test/java/com/github/dtreskunov/easyssl/ext/EnvResourceProtocolInConfigurationPropertiesTest.java
+++ b/src/test/java/com/github/dtreskunov/easyssl/ext/EnvResourceProtocolInConfigurationPropertiesTest.java
@@ -1,0 +1,64 @@
+package com.github.dtreskunov.easyssl.ext;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.Resource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StreamUtils;
+
+@SpringBootTest(properties = {"happy=env:HAPPY", "sad=env:SAD"}, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class EnvResourceProtocolInConfigurationPropertiesTest {
+    @Configuration
+    @EnableConfigurationProperties
+    @Import(EnvProtocolBeans.class)
+    public static class TestConfig {
+        @ConfigurationProperties
+        @Component
+        public static class Properties {
+            Resource happy;
+            Resource sad;
+            public Resource getHappy() {
+                return happy;
+            }
+            public void setHappy(Resource happy) {
+                this.happy = happy;
+            }
+            public Resource getSad() {
+                return sad;
+            }
+            public void setSad(Resource sad) {
+                this.sad = sad;
+            }
+        }
+    }
+
+    @Autowired
+    private TestConfig.Properties properties;
+
+    @Test
+    @SetEnvironmentVariable(key = "HAPPY", value = "happy")
+    public void testHappy() throws IOException {
+        assertThat(
+                StreamUtils.copyToString(properties.getHappy().getInputStream(), Charset.defaultCharset()),
+                is("happy"));
+    }
+
+    @Test
+    public void testSad() {
+        assertThrows(IOException.class, () ->
+            properties.getSad().getInputStream());
+    }
+}

--- a/src/test/java/com/github/dtreskunov/easyssl/ext/EnvResourceProtocolTest.java
+++ b/src/test/java/com/github/dtreskunov/easyssl/ext/EnvResourceProtocolTest.java
@@ -1,4 +1,4 @@
-package com.github.dtreskunov.easyssl;
+package com.github.dtreskunov.easyssl.ext;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -6,9 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-
-import com.github.dtreskunov.easyssl.ext.EnvProtocolBeans;
-import com.github.dtreskunov.easyssl.ext.EnvProtocolBeans.EnvironmentVariableNotSetException;
 
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
@@ -44,8 +41,8 @@ public class EnvResourceProtocolTest {
     }
 
     @Test
-    public void testSad() throws IOException {
-        assertThrows(EnvironmentVariableNotSetException.class, () ->
+    public void testSad() {
+        assertThrows(IOException.class, () ->
             resource.getInputStream());
     }
 }

--- a/src/test/java/com/github/dtreskunov/easyssl/ext/RefResourceProtocolTest.java
+++ b/src/test/java/com/github/dtreskunov/easyssl/ext/RefResourceProtocolTest.java
@@ -1,0 +1,56 @@
+package com.github.dtreskunov.easyssl.ext;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StreamUtils;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {"message=happy"})
+public class RefResourceProtocolTest {
+    @Configuration
+    @Import(RefProtocolBeans.class)
+    public static class TestConfig {
+        @Bean
+        public Resource happyResource(@Value("ref:message") Resource resource) {
+            return resource;
+        }
+        @Bean
+        public Resource sadResource(@Value("ref:missingProperty") Resource resource) {
+            return resource;
+        }
+    }
+
+    @Autowired
+    @Qualifier("happyResource")
+    private Resource happyResource;
+
+    @Autowired
+    @Qualifier("sadResource")
+    private Resource sadResource;
+
+    @Test
+    public void testHappy() throws IOException {
+        assertThat(
+                StreamUtils.copyToString(happyResource.getInputStream(), Charset.defaultCharset()),
+                is("happy"));
+    }
+
+    @Test
+    public void testSad() {
+        assertThrows(IOException.class, () ->
+            sadResource.getInputStream());
+    }
+}


### PR DESCRIPTION
Allows specifying Spring Resources as literals referencing application properties. For example, `ref:message` will result in a resource that will read from application property `message` when an _InputStream_ is requested (if message is not set, an _IOException_ is thrown).

To use this feature, make sure that _com.github.dtreskunov.easyssl.ext.RefProtocolBeans_ is getting imported by Spring. See included tests for an example.