### PR TITLE
use FIPS compliant BouncyCastle by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,24 +15,49 @@ jobs:
     - stage: test
       env:
         - ORG_GRADLE_PROJECT_servletContainer=tomcat
+        - ORG_GRADLE_PROJECT_fips=false
+      script:
+        - ./gradlew dependencies
+        - ./gradlew check
+    - stage: test
+      env:
+        - ORG_GRADLE_PROJECT_servletContainer=tomcat
+        - ORG_GRADLE_PROJECT_fips=true
       script:
         - ./gradlew dependencies
         - ./gradlew check
     - stage: test
       env:
         - ORG_GRADLE_PROJECT_servletContainer=jetty
+        - ORG_GRADLE_PROJECT_fips=false
+      script:
+        - ./gradlew dependencies
+        - ./gradlew check
+    - stage: test
+      env:
+        - ORG_GRADLE_PROJECT_servletContainer=jetty
+        - ORG_GRADLE_PROJECT_fips=true
       script:
         - ./gradlew dependencies
         - ./gradlew check
     - stage: test
       env:
         - ORG_GRADLE_PROJECT_servletContainer=undertow
+        - ORG_GRADLE_PROJECT_fips=false
+      script:
+        - ./gradlew dependencies
+        - ./gradlew check
+    - stage: test
+      env:
+        - ORG_GRADLE_PROJECT_servletContainer=undertow
+        - ORG_GRADLE_PROJECT_fips=true
       script:
         - ./gradlew dependencies
         - ./gradlew check
     - stage: deploy
       env:
         - ORG_GRADLE_PROJECT_servletContainer=tomcat
+        - ORG_GRADLE_PROJECT_fips=true
       script:
         - ./gradlew dependencies
         - |

--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ Maven:
 <dependency>
   <groupId>com.github.dtreskunov<groupId>
   <artifactId>easyssl</artifactId>
-  <version>2.1.1</version>
+  <version>2.1.2</version>
 </dependency>
 ```
 
 Gradle:
 ```groovy
-compile('com.github.dtreskunov:easyssl:2.1.1')
+compile('com.github.dtreskunov:easyssl:2.1.2')
 ```
 
 Next, add the following section to `application.yml`:
@@ -209,6 +209,10 @@ One useful trick to keep in mind is Spring's `Resource` abstraction. This is wha
 prefixes in `application.yml`. By default, EasySSL adds support for the `env:` protocol, which allows reading the contents
 of a `Resource` from an environment variable. It's possible to add a more suitable protocol depending on your infrastructure
 needs (for example, to access [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/)).
+
+# FIPS-140 compliance
+By default, EasySSL will use the [FIPS-compliant](https://en.wikipedia.org/wiki/FIPS_140) variant of the BouncyCastle library.
+If your project requires regular BouncyCastle, exclude the `bcpkix-fips` dependency and add `bcpkix-jdk15on`.
 
 # Links
 * [X.509 Authentication in Spring Security](http://www.baeldung.com/x-509-authentication-in-spring-security)

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ dependencies {
   api('org.slf4j:slf4j-api')
   api('javax.validation:validation-api:2.0.1.Final')
   api('javax.servlet:javax.servlet-api')
-  api('org.bouncycastle:bcpkix-jdk15on:1.69')
+  api(project.getProperties().getOrDefault('fips', 'true').toBoolean() ? 'org.bouncycastle:bcpkix-fips:1.0.5' : 'org.bouncycastle:bcpkix-jdk15on:1.69')
   compileOnly('org.eclipse.jetty:jetty-server') // needed for jetty-specific customizations
   compileOnly('org.apache.tomcat.embed:tomcat-embed-core') // needed for tomcat-specific customizations
   compileOnly('io.undertow:undertow-core') // needed for undertow-specific customizations

--- a/src/main/java/com/github/dtreskunov/easyssl/EasySslBeans.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/EasySslBeans.java
@@ -1,6 +1,5 @@
 package com.github.dtreskunov.easyssl;
 
-import java.security.Security;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,10 +47,6 @@ public class EasySslBeans {
     @ConditionalOnWebApplication
     @ConditionalOnProperty(value = "easyssl.serverCustomizationEnabled", matchIfMissing = true)
     public static @interface ConditionalOnServerCustomizationEnabled {}
-
-    static {
-        Security.addProvider(new org.bouncycastle.jce.provider.BouncyCastleProvider());
-    }
 
     /**
      * Only used by test code

--- a/src/main/java/com/github/dtreskunov/easyssl/EasySslHelper.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/EasySslHelper.java
@@ -12,8 +12,10 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.security.Provider;
 import java.security.PublicKey;
 import java.security.SecureRandom;
+import java.security.Security;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
@@ -158,12 +160,37 @@ public class EasySslHelper implements ApplicationEventPublisherAware {
         return sslStoreProvider;
     }
 
+    private static void addSecurityProvider(String declaredName, String className) throws Exception {
+        Provider provider = Security.getProvider(declaredName);
+        if (provider != null) {
+            return;
+        }
+        provider = (Provider) Class.forName(className).getDeclaredConstructor().newInstance();
+        Security.addProvider(provider);
+        LOG.info("Security Provider added: {}", provider.getInfo());
+    }
+
+    private static void addBouncyCastleSecurityProvider() {
+        try {
+            addSecurityProvider("BCFIPS", "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider");
+        } catch (Exception e1) {
+            LOG.debug("BouncyCastleFipsProvider could not be added", e1);
+            try {
+                addSecurityProvider("BC", "org.bouncycastle.jce.provider.BouncyCastleProvider");
+            } catch (Exception e2) {
+                LOG.error("BouncyCastleProvider could not be added, giving up", e2);
+                throw new RuntimeException(e2);
+            }
+        }
+    }
+
     private void initialize() {
         LOG.info("{} EasySSL with command {}, certificate from {}, key from {}, CA from {}, and CRL from {} with timeout {} (disabled if zero). Next update in {} (disabled if zero)",
             initialized ? "Reinitializing" : "Initializing", config.getRefreshCommand(),
             config.getCertificate(), config.getKey(), config.getCaCertificate(), config.getCertificateRevocationList(),
             config.getRefreshTimeout(), config.getRefreshInterval());
         try {
+            addBouncyCastleSecurityProvider();
             if (config.getRefreshCommand() != null) {
                 LOG.info("Refresh command: {}", config.getRefreshCommand());
                 Process refreshProcess = Runtime.getRuntime().exec(
@@ -228,7 +255,7 @@ public class EasySslHelper implements ApplicationEventPublisherAware {
             throw new KeyException("No object was extracted from the input stream by the PEM parser");
         }
 
-        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider("BC");
+        JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
         final PEMKeyPair pemKeyPair;
         final KeyPair keyPair;
         if (pemObject instanceof PEMEncryptedKeyPair) {

--- a/src/main/java/com/github/dtreskunov/easyssl/EasySslHelper.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/EasySslHelper.java
@@ -174,11 +174,11 @@ public class EasySslHelper implements ApplicationEventPublisherAware {
         try {
             addSecurityProvider("BCFIPS", "org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider");
         } catch (Exception e1) {
-            LOG.debug("BouncyCastleFipsProvider could not be added", e1);
+            LOG.debug("BouncyCastleFipsProvider could not be added");
             try {
                 addSecurityProvider("BC", "org.bouncycastle.jce.provider.BouncyCastleProvider");
             } catch (Exception e2) {
-                LOG.error("BouncyCastleProvider could not be added, giving up", e2);
+                LOG.error("Neither BouncyCastleFipsProvider nor BouncyCastleProvider could not be added");
                 throw new RuntimeException(e2);
             }
         }


### PR DESCRIPTION
https://en.wikipedia.org/wiki/FIPS_140

This is accomplished by replacing the bcpkix-jdk15on dependency with
bcpkix-fips. If the original dependency is required by the project, exclude
the fips dependency and add the original one back in.

Both dependencies are fully tested with all supported servlet containers.