### PR TITLE
Add API for accessing CA certs, private key, cert chain, and CRL

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ Maven:
 <dependency>
   <groupId>com.github.dtreskunov<groupId>
   <artifactId>easyssl</artifactId>
-  <version>2.1.3</version>
+  <version>2.2.0</version>
 </dependency>
 ```
 
 Gradle:
 ```groovy
-compile('com.github.dtreskunov:easyssl:2.1.3')
+compile('com.github.dtreskunov:easyssl:2.2.0')
 ```
 
 Next, add the following section to `application.yml`:

--- a/src/main/java/com/github/dtreskunov/easyssl/CRLTrustManager.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/CRLTrustManager.java
@@ -1,23 +1,18 @@
 package com.github.dtreskunov.easyssl;
 
 import java.security.PublicKey;
-import java.security.SignatureException;
 import java.security.cert.CRLReason;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateRevokedException;
 import java.security.cert.X509CRL;
 import java.security.cert.X509CRLEntry;
 import java.security.cert.X509Certificate;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
 
 import javax.net.ssl.X509TrustManager;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.util.Assert;
 
@@ -28,29 +23,11 @@ import org.springframework.util.Assert;
  * some of provided {@link PublicKey}s (there may be several CAs).
  */
 class CRLTrustManager implements X509TrustManager {
-    private static final Logger LOG = LoggerFactory.getLogger(CRLTrustManager.class);
-
     private final X509CRL m_crl;
 
-    public CRLTrustManager(Resource crlResource, Collection<PublicKey> publicKeys) throws Exception {
-        Assert.notNull(crlResource, "crlResource may not be null");
-        Assert.notNull(publicKeys, "publicKeys may not be null");
-        m_crl = loadCRL(crlResource, publicKeys);
-    }
-
-    private static X509CRL loadCRL(Resource resource, Collection<PublicKey> publicKeys) throws Exception {
-        X509CRL crl = (X509CRL) CertificateFactory.getInstance("X.509").generateCRL(resource.getInputStream());
-        for (PublicKey publicKey: publicKeys) {
-            try {
-                crl.verify(publicKey);
-                LOG.info("Loaded CRL from {}", resource);
-                return crl;
-            } catch (Exception e) {
-                LOG.debug("Unable to verify CRL from {} against a public key {} due to {}", resource, publicKey, e.toString());
-                continue;
-            }
-        }
-        throw new SignatureException("Unable to verify CRL against any provided public keys");
+    CRLTrustManager(X509CRL crl) throws Exception {
+        Assert.notNull(crl, "crl may not be null");
+        m_crl = crl;
     }
 
     @Override

--- a/src/main/java/com/github/dtreskunov/easyssl/EasySslJettyCustomizer.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/EasySslJettyCustomizer.java
@@ -24,6 +24,10 @@ class EasySslJettyCustomizer implements WebServerFactoryCustomizer<ConfigurableJ
 
     @Override
     public void onApplicationEvent(SSLContextReinitializedEvent event) {
+        if (!contextFactory.isSet()) {
+            LOG.warn("Jetty hasn't been configured yet - remove it from classpath if not using");
+            return;
+        }
         LOG.info("Updating Jetty with new SSLContext");
         contextFactory.get().setKeyStore(event.getHelper().getKeyStore());
         contextFactory.get().setTrustStore(event.getHelper().getTrustStore());

--- a/src/main/java/com/github/dtreskunov/easyssl/EasySslUndertowCustomizer.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/EasySslUndertowCustomizer.java
@@ -29,6 +29,10 @@ class EasySslUndertowCustomizer implements ApplicationListener<ApplicationEvent>
     }
 
     private void onWebServerInitializedEvent(WebServerInitializedEvent event) {
+        if (!(event.getWebServer() instanceof UndertowWebServer)) {
+            LOG.warn("Undertow isn't being used - remove it from classpath if not using");
+            return;
+        }
         UndertowWebServer server = (UndertowWebServer) event.getWebServer();
         Field UndertowWebServer_undertow = ReflectionUtils.findField(UndertowWebServer.class, "undertow");
         ReflectionUtils.makeAccessible(UndertowWebServer_undertow);
@@ -41,6 +45,10 @@ class EasySslUndertowCustomizer implements ApplicationListener<ApplicationEvent>
     }
 
     private void onSSLContextReinitializedEvent(SSLContextReinitializedEvent event) {
+        if (!httpsListenerInfo.isSet()) {
+            LOG.warn("Undertow hasn't been configured yet - remove it from classpath if not using");
+            return;
+        }
         LOG.info("Updating Undertow with new SSLContext");
         httpsListenerInfo.get().setSslContext(event.getHelper().getSSLContext());
     }

--- a/src/main/java/com/github/dtreskunov/easyssl/SetOnlyOnce.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/SetOnlyOnce.java
@@ -17,4 +17,8 @@ class SetOnlyOnce<T> {
         }
         return value;
     }
+
+    public boolean isSet() {
+        return value != null;
+    }
 }


### PR DESCRIPTION
New APIs in EasySslHelper:
* `getCACertificates()`
* `getCRL()`
* `getCertificateChain()`
* `getPrivateKey()`
