### PR TITLE
make compatible with boot 2.6 by removing circular reference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ repositories {
 }
 
 dependencies {
-  implementation platform('org.springframework.boot:spring-boot-dependencies:2.5.3')
+  implementation platform('org.springframework.boot:spring-boot-dependencies:2.6.6')
   api('org.springframework.boot:spring-boot')
   api('org.springframework.boot:spring-boot-autoconfigure')
   api('org.springframework:spring-web')

--- a/src/main/java/com/github/dtreskunov/easyssl/EasySslBeans.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/EasySslBeans.java
@@ -58,12 +58,6 @@ public class EasySslBeans {
 
     @Bean
     @ConditionalOnEnabled
-    public EasySslProperties easySslProperties() {
-        return new EasySslProperties();
-    }
-
-    @Bean
-    @ConditionalOnEnabled
     public EasySslHelper easySslHelper(EasySslProperties config) throws Exception {
         return new EasySslHelper(config);
     }

--- a/src/main/java/com/github/dtreskunov/easyssl/EasySslProperties.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/EasySslProperties.java
@@ -5,8 +5,11 @@ import java.util.List;
 
 import javax.validation.constraints.NotNull;
 
-import org.springframework.boot.web.server.Ssl.ClientAuth;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.web.server.Ssl.ClientAuth;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.validation.annotation.Validated;
 
@@ -31,6 +34,16 @@ import org.springframework.validation.annotation.Validated;
 @Validated
 @ConfigurationProperties(prefix = "easyssl")
 public class EasySslProperties {
+
+    @Configuration
+    @ConditionalOnProperty(value = "easyssl.enabled", matchIfMissing = true)
+    static class EasySslPropertiesConfiguration {
+        @Bean
+        EasySslProperties easySslProperties() {
+            return new EasySslProperties();
+        }
+
+    }
 
     @NotNull
     private List<Resource> m_caCertificate;

--- a/src/test/java/com/github/dtreskunov/easyssl/IntegrationTestUsingMockMvc.java
+++ b/src/test/java/com/github/dtreskunov/easyssl/IntegrationTestUsingMockMvc.java
@@ -1,5 +1,10 @@
 package com.github.dtreskunov.easyssl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.github.dtreskunov.easyssl.server.Server;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -9,14 +14,18 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import com.github.dtreskunov.easyssl.server.Server;
-
 @SpringBootTest(properties = {"spring.profiles.active=test"}, classes = {Server.class})
 @AutoConfigureMockMvc
 public class IntegrationTestUsingMockMvc {
 
     @Autowired
     private MockMvc mvc;
+
+    @Test
+    public void sanity(@Autowired EasySslBeans beans, @Autowired EasySslProperties config) {
+        assertThat(beans, notNullValue());
+        assertThat(config, notNullValue());
+    }
 
     @Test
     public void protectedEndpoint_forbidden() throws Exception {

--- a/src/test/java/com/github/dtreskunov/easyssl/IntegrationTestWhenDisabled.java
+++ b/src/test/java/com/github/dtreskunov/easyssl/IntegrationTestWhenDisabled.java
@@ -10,11 +10,15 @@
 // -----------------------------------------------------------------------------
 package com.github.dtreskunov.easyssl;
 
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.context.SpringBootTest;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 
 import com.github.dtreskunov.easyssl.IntegrationTestWhenDisabled.ScanConfiguration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(properties = {"easyssl.enabled=false"}, classes = {ScanConfiguration.class})
 public class IntegrationTestWhenDisabled {
@@ -22,5 +26,8 @@ public class IntegrationTestWhenDisabled {
     public static class ScanConfiguration {}
 
     @Test
-    public void sanity() {}
+    public void sanity(@Autowired(required = false) EasySslBeans beans, @Autowired(required = false) EasySslProperties config) {
+        assertThat(beans, nullValue());
+        assertThat(config, nullValue());
+    }
 }


### PR DESCRIPTION
Spring Boot 2.6 prohibits circular references by default [1]. This commit
resolves a circular reference in EasySslBeans bean by moving EasySslProperties
into a separate @Configuration bean factory. Backwards compatibility
with Spring Boot 2.5.3 was validated manually by undoing the version change
in build.gradle.

1. https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes