### PR TITLE
make custom ResourceLoader public

### DIFF
--- a/src/main/java/com/github/dtreskunov/easyssl/ext/ApplicationPropertyResource.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/ext/ApplicationPropertyResource.java
@@ -1,0 +1,19 @@
+package com.github.dtreskunov.easyssl.ext;
+
+import org.springframework.core.env.Environment;
+import org.springframework.util.Assert;
+
+public class ApplicationPropertyResource extends AbstractNamedResource {
+    private final Environment environment;
+
+    public ApplicationPropertyResource(String name, Environment environment) {
+        super(name);
+        Assert.notNull(environment, "environment cannot be null");
+        this.environment = environment;
+    }
+
+    @Override
+    String getValue(String name) {
+        return environment.getProperty(name);
+    }
+}

--- a/src/main/java/com/github/dtreskunov/easyssl/ext/AwsSecretsManagerProtocolBeans.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/ext/AwsSecretsManagerProtocolBeans.java
@@ -37,7 +37,7 @@ public class AwsSecretsManagerProtocolBeans {
         return new ProtocolResolverRegistrar(new AwsSecretsManagerProtocolResolver(secretsManager));
     }
 
-    static class AwsSecretsManagerProtocolResolver implements ProtocolResolver {
+    public static class AwsSecretsManagerProtocolResolver implements ProtocolResolver {
         public static final String PROTOCOL_PREFIX = "aws-secrets-manager:";
         private final AWSSecretsManager secretsManager;
 
@@ -56,7 +56,7 @@ public class AwsSecretsManagerProtocolBeans {
         }
     }
 
-    static class AwsSecretsManagerResource extends AbstractNamedResource {
+    public static class AwsSecretsManagerResource extends AbstractNamedResource {
         private final Logger log = LoggerFactory.getLogger(AwsSecretsManagerResource.class);
         private final AWSSecretsManager secretsManager;
 

--- a/src/main/java/com/github/dtreskunov/easyssl/ext/EnvProtocolBeans.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/ext/EnvProtocolBeans.java
@@ -5,9 +5,7 @@ import java.io.InputStream;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.ProtocolResolver;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
 
 /**
  * Allows specifying Spring {@link Resource}s as literals from environment
@@ -22,30 +20,5 @@ public class EnvProtocolBeans {
     @Bean
     ProtocolResolverRegistrar envProtocolResolverRegistrar() {
         return new ProtocolResolverRegistrar(new EnvProtocolResolver());
-    }
-
-    static class EnvProtocolResolver implements ProtocolResolver {
-        public static final String ENV_PROTOCOL_PREFIX = "env:";
-
-        @Override
-        public Resource resolve(String location, ResourceLoader resourceLoader) {
-            if (!location.startsWith(ENV_PROTOCOL_PREFIX)) {
-                return null;
-            }
-            String environmentVariableName = location.substring(ENV_PROTOCOL_PREFIX.length());
-            return new EnvironmentVariableResource(environmentVariableName);
-        }
-    }
-
-    static class EnvironmentVariableResource extends AbstractNamedResource {
-
-        public EnvironmentVariableResource(String name) {
-            super(name);
-        }
-
-        @Override
-        String getValue(String name) {
-            return System.getenv(name);
-        }
     }
 }

--- a/src/main/java/com/github/dtreskunov/easyssl/ext/EnvProtocolResolver.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/ext/EnvProtocolResolver.java
@@ -1,0 +1,18 @@
+package com.github.dtreskunov.easyssl.ext;
+
+import org.springframework.core.io.ProtocolResolver;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+public class EnvProtocolResolver implements ProtocolResolver {
+    public static final String ENV_PROTOCOL_PREFIX = "env:";
+
+    @Override
+    public Resource resolve(String location, ResourceLoader resourceLoader) {
+        if (!location.startsWith(ENV_PROTOCOL_PREFIX)) {
+            return null;
+        }
+        String environmentVariableName = location.substring(ENV_PROTOCOL_PREFIX.length());
+        return new EnvironmentVariableResource(environmentVariableName);
+    }
+}

--- a/src/main/java/com/github/dtreskunov/easyssl/ext/EnvironmentVariableResource.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/ext/EnvironmentVariableResource.java
@@ -1,0 +1,13 @@
+package com.github.dtreskunov.easyssl.ext;
+
+public class EnvironmentVariableResource extends AbstractNamedResource {
+
+    public EnvironmentVariableResource(String name) {
+        super(name);
+    }
+
+    @Override
+    String getValue(String name) {
+        return System.getenv(name);
+    }
+}

--- a/src/main/java/com/github/dtreskunov/easyssl/ext/RefProtocolBeans.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/ext/RefProtocolBeans.java
@@ -6,10 +6,7 @@ import java.io.InputStream;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
-import org.springframework.core.io.ProtocolResolver;
 import org.springframework.core.io.Resource;
-import org.springframework.core.io.ResourceLoader;
-import org.springframework.util.Assert;
 
 /**
  * Allows specifying Spring {@link Resource}s as literals referencing application
@@ -24,39 +21,5 @@ public class RefProtocolBeans {
     @Bean
     ProtocolResolverRegistrar refProtocolResolverRegistrar(Environment environment) {
         return new ProtocolResolverRegistrar(new RefProtocolResolver(environment));
-    }
-
-    static class RefProtocolResolver implements ProtocolResolver {
-        public static final String PROTOCOL_PREFIX = "ref:";
-        private final Environment environment;
-
-        public RefProtocolResolver(Environment environment) {
-            Assert.notNull(environment, "environment cannot be null");
-            this.environment = environment;
-        }
-
-        @Override
-        public Resource resolve(String location, ResourceLoader resourceLoader) {
-            if (!location.startsWith(PROTOCOL_PREFIX)) {
-                return null;
-            }
-            String name = location.substring(PROTOCOL_PREFIX.length());
-            return new ApplicationPropertyResource(name, environment);
-        }
-    }
-
-    static class ApplicationPropertyResource extends AbstractNamedResource {
-        private final Environment environment;
-
-        public ApplicationPropertyResource(String name, Environment environment) {
-            super(name);
-            Assert.notNull(environment, "environment cannot be null");
-            this.environment = environment;
-        }
-
-        @Override
-        String getValue(String name) {
-            return environment.getProperty(name);
-        }
     }
 }

--- a/src/main/java/com/github/dtreskunov/easyssl/ext/RefProtocolResolver.java
+++ b/src/main/java/com/github/dtreskunov/easyssl/ext/RefProtocolResolver.java
@@ -1,0 +1,26 @@
+package com.github.dtreskunov.easyssl.ext;
+
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.ProtocolResolver;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.util.Assert;
+
+public class RefProtocolResolver implements ProtocolResolver {
+    public static final String PROTOCOL_PREFIX = "ref:";
+    private final Environment environment;
+
+    public RefProtocolResolver(Environment environment) {
+        Assert.notNull(environment, "environment cannot be null");
+        this.environment = environment;
+    }
+
+    @Override
+    public Resource resolve(String location, ResourceLoader resourceLoader) {
+        if (!location.startsWith(PROTOCOL_PREFIX)) {
+            return null;
+        }
+        String name = location.substring(PROTOCOL_PREFIX.length());
+        return new ApplicationPropertyResource(name, environment);
+    }
+}

--- a/src/test/java/com/github/dtreskunov/easyssl/ext/AwsSecretsManagerResourceProtocolTest.java
+++ b/src/test/java/com/github/dtreskunov/easyssl/ext/AwsSecretsManagerResourceProtocolTest.java
@@ -7,8 +7,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -17,6 +21,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StreamUtils;
 
@@ -25,54 +31,106 @@ import com.amazonaws.services.secretsmanager.model.AWSSecretsManagerException;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-public class AwsSecretsManagerResourceProtocolTest {
-    @Configuration
-    @Import(AwsSecretsManagerProtocolBeans.class)
-    public static class TestConfig {
-        @MockBean
-        private AWSSecretsManager secretsManager;
-
-        @Bean
-        public Resource happyResource(@Value("aws-secrets-manager:happy") Resource resource) {
-            return resource;
-        }
-        @Bean
-        public Resource sadResource(@Value("aws-secrets-manager:sad") Resource resource) {
-            return resource;
-        }
-    }
-
-    @Autowired
-    private AWSSecretsManager secretsManager;
-
-    @Autowired
-    @Qualifier("happyResource")
-    private Resource happyResource;
-
-    @Autowired
-    @Qualifier("sadResource")
-    private Resource sadResource;
+public abstract class AwsSecretsManagerResourceProtocolTest {
 
     @Test
     public void testHappy() throws IOException {
+        assertThat(
+            StreamUtils.copyToString(getHappyResource().getInputStream(), Charset.defaultCharset()),
+            is("awesome"));
+    }
+
+    @Test
+    public void testSad() {
+        assertThrows(AWSSecretsManagerException.class, () ->
+            getSadResource().getInputStream());
+    }
+
+    abstract Resource getHappyResource();
+    abstract Resource getSadResource();
+
+    static void setupHappy(AWSSecretsManager secretsManager) {
         GetSecretValueRequest mockedRequest = new GetSecretValueRequest().withSecretId("happy");
         GetSecretValueResult mockedResult = new GetSecretValueResult().withSecretString("awesome");
         Mockito
             .when(secretsManager.getSecretValue(mockedRequest))
             .thenReturn(mockedResult);
-        assertThat(
-                StreamUtils.copyToString(happyResource.getInputStream(), Charset.defaultCharset()),
-                is("awesome"));
     }
 
-    @Test
-    public void testSad() {
+    static void setupSad(AWSSecretsManager secretsManager) {
         GetSecretValueRequest mockedRequest = new GetSecretValueRequest().withSecretId("sad");
         Mockito
             .when(secretsManager.getSecretValue(mockedRequest))
             .thenThrow(new AWSSecretsManagerException("test"));
-        assertThrows(AWSSecretsManagerException.class, () ->
-            sadResource.getInputStream());
+    }
+
+    @ExtendWith(MockitoExtension.class)
+    static class LightweightResourceLoaderTest extends AwsSecretsManagerResourceProtocolTest {
+
+        DefaultResourceLoader resourceLoader;
+    
+        @Mock
+        private AWSSecretsManager secretsManager;
+
+        @BeforeEach
+        void beforeEach() {
+            resourceLoader = new StaticApplicationContext();
+            resourceLoader.addProtocolResolver(new AwsSecretsManagerProtocolBeans.AwsSecretsManagerProtocolResolver(secretsManager));
+        }
+    
+        @Override
+        Resource getHappyResource() {
+            setupHappy(secretsManager);
+            return resourceLoader.getResource("aws-secrets-manager:happy");
+        }
+
+        @Override
+        Resource getSadResource() {
+            setupSad(secretsManager);
+            return resourceLoader.getResource("aws-secrets-manager:sad");
+        }
+    }
+
+    @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+    static class IntegrationTest extends AwsSecretsManagerResourceProtocolTest {
+        @Configuration
+        @Import(AwsSecretsManagerProtocolBeans.class)
+        public static class TestConfig {
+
+            @MockBean
+            private AWSSecretsManager secretsManager;
+    
+            @Bean
+            public Resource happyResource(@Value("aws-secrets-manager:happy") Resource resource) {
+                return resource;
+            }
+            @Bean
+            public Resource sadResource(@Value("aws-secrets-manager:sad") Resource resource) {
+                return resource;
+            }
+        }
+
+        @Autowired
+        private AWSSecretsManager secretsManager;
+
+        @Autowired
+        @Qualifier("happyResource")
+        private Resource happyResource;
+
+        @Autowired
+        @Qualifier("sadResource")
+        private Resource sadResource;
+
+        @Override
+        Resource getHappyResource() {
+            setupHappy(secretsManager);
+            return happyResource;
+        }
+
+        @Override
+        Resource getSadResource() {
+            setupSad(secretsManager);
+            return sadResource;
+        }
     }
 }

--- a/src/test/java/com/github/dtreskunov/easyssl/ext/RefResourceProtocolTest.java
+++ b/src/test/java/com/github/dtreskunov/easyssl/ext/RefResourceProtocolTest.java
@@ -3,11 +3,16 @@ package com.github.dtreskunov.easyssl.ext;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,42 +20,86 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.util.StreamUtils;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {"message=happy"})
-public class RefResourceProtocolTest {
-    @Configuration
-    @Import(RefProtocolBeans.class)
-    public static class TestConfig {
-        @Bean
-        public Resource happyResource(@Value("ref:message") Resource resource) {
-            return resource;
-        }
-        @Bean
-        public Resource sadResource(@Value("ref:missingProperty") Resource resource) {
-            return resource;
-        }
-    }
-
-    @Autowired
-    @Qualifier("happyResource")
-    private Resource happyResource;
-
-    @Autowired
-    @Qualifier("sadResource")
-    private Resource sadResource;
+public abstract class RefResourceProtocolTest {
 
     @Test
     public void testHappy() throws IOException {
         assertThat(
-                StreamUtils.copyToString(happyResource.getInputStream(), Charset.defaultCharset()),
+                StreamUtils.copyToString(getHappyResource().getInputStream(), Charset.defaultCharset()),
                 is("happy"));
     }
 
     @Test
     public void testSad() {
         assertThrows(IOException.class, () ->
-            sadResource.getInputStream());
+            getSadResource().getInputStream());
+    }
+
+    abstract Resource getHappyResource();
+    abstract Resource getSadResource();
+
+    @ExtendWith(MockitoExtension.class)
+    static class LightweightResourceLoaderTest extends RefResourceProtocolTest {
+        DefaultResourceLoader resourceLoader;
+        
+        @Mock
+        Environment env;
+    
+        @BeforeEach
+        void beforeEach() {
+            resourceLoader = new StaticApplicationContext();
+            resourceLoader.addProtocolResolver(new RefProtocolResolver(env));
+        }
+    
+        @Override
+        Resource getHappyResource() {
+            when(env.getProperty("message")).thenReturn("happy");
+            return resourceLoader.getResource("ref:message");
+        }
+
+        @Override
+        Resource getSadResource() {
+            return resourceLoader.getResource("ref:missingProperty");
+        }
+    }
+
+    @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, properties = {"message=happy"})
+    static class IntegrationTest extends RefResourceProtocolTest {
+        @Configuration
+        @Import(RefProtocolBeans.class)
+        public static class TestConfig {
+            @Bean
+            public Resource happyResource(@Value("ref:message") Resource resource) {
+                return resource;
+            }
+            @Bean
+            public Resource sadResource(@Value("ref:missingProperty") Resource resource) {
+                return resource;
+            }
+        }
+
+        @Autowired
+        @Qualifier("happyResource")
+        private Resource happyResource;
+
+        @Autowired
+        @Qualifier("sadResource")
+        private Resource sadResource;
+
+        @Override
+        Resource getHappyResource() {
+            return happyResource;
+        }
+
+        @Override
+        Resource getSadResource() {
+            return sadResource;
+        }
     }
 }


### PR DESCRIPTION
This allows using these ResourceLoader implementations without having a full-blown Spring Application Context.

Add tests demoing how to use them.